### PR TITLE
feat: Add PUT, PATCH, and DELETE route methods for full REST API support

### DIFF
--- a/src/Routing/RouteManager.php
+++ b/src/Routing/RouteManager.php
@@ -74,6 +74,21 @@ class RouteManager
         return $this->addRoute('POST', $uri, $action);
     }
 
+    public function put(string $uri, $action)
+    {
+        return $this->addRoute('PUT', $uri, $action);
+    }
+
+    public function patch(string $uri, $action)
+    {
+        return $this->addRoute('PATCH', $uri, $action);
+    }
+
+    public function delete(string $uri, $action)
+    {
+        return $this->addRoute('DELETE', $uri, $action);
+    }
+
 
     public function loadRoutes()
     {


### PR DESCRIPTION
- WordPress's register_rest_route() supports all standard HTTP methods (GET, POST, PUT, PATCH, DELETE), but the RouteManager only exposed get() and post(). This adds the missing put(), patch(), and delete() convenience methods following the exact same addRoute() pattern, enabling plugins to define RESTful routes with proper HTTP verb semantics.