### PR TITLE
Added missing adapter PHP Deprecated Error Fix

### DIFF
--- a/src/DB/QueryBuilder/QueryBuilderHandler.php
+++ b/src/DB/QueryBuilder/QueryBuilderHandler.php
@@ -43,6 +43,16 @@ class QueryBuilderHandler
     protected $adapterInstance;
 
     /**
+     * @var string
+     */
+    protected $adapter;
+
+    /**
+     * @var array
+     */
+    protected $adapterConfig;
+
+    /**
      * The PDO fetch parameters to use
      *
      * @var array


### PR DESCRIPTION
- The properties `$adapter` and `$adapterConfig` were undeclared inside that class resulting in strict error deprecation logs in PHP `8.2`. I updated that library's core class to explicitly define those protected variables inside `wpdrill/core/src/DB/QueryBuilder/QueryBuilderHandler.php`